### PR TITLE
[Feat] Add user, cart and ticket enum type with minors changes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,27 +7,60 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model Categoria {
-  id      Int      @id @default(autoincrement())
-  nome    String
-  eventos Evento[]
-}
 
-model Evento {
-  id           Int        @id @default(autoincrement())
-  titulo       String
-  descricao    String
-  endereco     String
-  dataInicio   DateTime?
-  dataTermino  DateTime?
-  ticketType   TicketType @default(INGRESSO)
-  imagemUrl    String?
-  categoriaId  Int
-  categoria    Categoria  @relation(fields: [categoriaId], references: [id])
+enum CategoriaEnum {
+  SHOWS_ENTRETENIMENTO
+  WORKSHOPS_AULAS
+  VIAGENS_TURISMO
+  AVENTURA_ADRENALINA
+  RELAXAMENTO_BEM_ESTAR
+  GASTRONOMIA_DEGUSTACOES
+  INFANTIL_FAMILIAR
+  EXPERIENCIAS_PERSONALIZADAS
 }
 
 enum TicketType {
   INGRESSO
   VIP
   GRATUITO
+}
+
+model Evento {
+  id           Int           @id @default(autoincrement())
+  titulo       String
+  descricao    String
+  endereco     String
+  dataInicio   DateTime?     
+  dataTermino  DateTime?
+  ticketType   TicketType    @default(INGRESSO)
+  imagemUrl    String?       @default("https://exemplo.com/placeholder.jpg")
+  preco        Float?        @default(0) 
+  categoria    CategoriaEnum 
+   carrinhoItems CarrinhoItem[]
+}
+
+
+model Usuario {
+  id       Int      @id @default(autoincrement())
+  email    String   @unique
+  senha    String
+  nome     String?
+  carrinho Carrinho?
+}
+
+model Carrinho {
+  id         Int       @id @default(autoincrement())
+  usuario    Usuario   @relation(fields: [usuarioId], references: [id])
+  usuarioId  Int       @unique 
+  itens      CarrinhoItem[]
+}
+
+// Modelo auxiliar para itens do carrinho
+model CarrinhoItem {
+  id         Int      @id @default(autoincrement())
+  carrinho   Carrinho @relation(fields: [carrinhoId], references: [id])
+  carrinhoId Int
+  evento     Evento   @relation(fields: [eventoId], references: [id])
+  eventoId   Int
+  quantidade Int      @default(1)
 }


### PR DESCRIPTION
## Description
This pull request includes significant changes to the Prisma schema, focusing on the restructuring of models and the addition of new enums and models to better represent the application's data.

### Schema Restructuring:

* **Enum Creation:**
  * Added `CategoriaEnum` to replace the `Categoria` model, providing predefined categories for events.
  * Introduced `TicketType` enum to categorize different types of tickets.

* **Model Updates:**
  * Modified the `Evento` model to use `CategoriaEnum` instead of the `Categoria` model, added default values for `imagemUrl` and `preco`, and included a relation to `CarrinhoItem`.

### New Models:

* **User and Cart Management:**
  * Added `Usuario` model to represent users, including fields for email, password, and an optional name, with a relation to the `Carrinho` model.
  * Created `Carrinho` model to represent shopping carts, with a unique relation to the `Usuario` model and a list of `CarrinhoItem` objects.
  * Introduced `CarrinhoItem` model as an auxiliary model to manage items within a cart, including relations to both `Carrinho` and `Evento` models, and a default quantity.