### PR TITLE
[Feature] Card size component

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,11 @@ enum TicketType {
   GRATUITO
 }
 
+enum CardSize {
+  NORMAL
+  LARGE
+}
+
 model Evento {
   id           Int           @id @default(autoincrement())
   titulo       String
@@ -34,7 +39,8 @@ model Evento {
   ticketType   TicketType    @default(INGRESSO)
   imagemUrl    String?       @default("https://exemplo.com/placeholder.jpg")
   preco        Float?        @default(0) 
-  categoria    CategoriaEnum 
+  categoria    CategoriaEnum
+  cardSize     CardSize      @default(NORMAL)
   carrinhoItems CarrinhoItem[]
 }
 

--- a/src/controllers/eventoController.js
+++ b/src/controllers/eventoController.js
@@ -159,6 +159,7 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/show-rock.jpg',
         preco: 150.0,
         categoria: 'SHOWS_ENTRETENIMENTO',
+        cardSize: 'NORMAL',
       },
       {
         titulo: 'Festival de Jazz',
@@ -170,6 +171,7 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/jazz-festival.jpg',
         preco: 200.0,
         categoria: 'SHOWS_ENTRETENIMENTO',
+        cardSize: 'NORMAL',
       },
       {
         titulo: 'Noite de Sertanejo',
@@ -181,6 +183,7 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/sertanejo-night.jpg',
         preco: 0.0,
         categoria: 'SHOWS_ENTRETENIMENTO',
+        cardSize: 'NORMAL',
       },
       {
         titulo: 'Festival EDM',
@@ -192,6 +195,7 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/edm-festival.jpg',
         preco: 300.0,
         categoria: 'SHOWS_ENTRETENIMENTO',
+        cardSize: 'NORMAL',
       },
       {
         titulo: 'Concerto de Orquestra',
@@ -203,8 +207,8 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/orquestra.jpg',
         preco: 250.0,
         categoria: 'SHOWS_ENTRETENIMENTO',
+        cardSize: 'NORMAL',
       },
-
       {
         titulo: 'Passeio de Quadriciclo',
         descricao: 'Aventura off-road em trilhas emocionantes.',
@@ -215,6 +219,7 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/quadriciclo.jpg',
         preco: 120.0,
         categoria: 'AVENTURA_ADRENALINA',
+        cardSize: 'NORMAL',
       },
       {
         titulo: 'Salto de Paraquedas',
@@ -226,6 +231,7 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/paraquedas.jpg',
         preco: 500.0,
         categoria: 'AVENTURA_ADRENALINA',
+        cardSize: 'NORMAL',
       },
       {
         titulo: 'Rafting no Rio',
@@ -237,6 +243,7 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/rafting.jpg',
         preco: 180.0,
         categoria: 'AVENTURA_ADRENALINA',
+        cardSize: 'NORMAL',
       },
       {
         titulo: 'Tirolesa na Montanha',
@@ -248,6 +255,7 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/tirolesa.jpg',
         preco: 90.0,
         categoria: 'AVENTURA_ADRENALINA',
+        cardSize: 'NORMAL',
       },
       {
         titulo: 'Escalada em Rocha',
@@ -259,8 +267,8 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/escalada.jpg',
         preco: 220.0,
         categoria: 'AVENTURA_ADRENALINA',
+        cardSize: 'NORMAL',
       },
-
       {
         titulo: 'Jantar Gourmet',
         descricao: 'Um jantar sofisticado com pratos exclusivos.',
@@ -271,6 +279,7 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/jantar-gourmet.jpg',
         preco: 350.0,
         categoria: 'GASTRONOMIA_DEGUSTACOES',
+        cardSize: 'NORMAL',
       },
       {
         titulo: 'Degustação de Vinhos',
@@ -282,6 +291,7 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/degustacao-vinhos.jpg',
         preco: 150.0,
         categoria: 'GASTRONOMIA_DEGUSTACOES',
+        cardSize: 'NORMAL',
       },
       {
         titulo: 'Workshop de Chocolates',
@@ -293,6 +303,7 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/workshop-chocolates.jpg',
         preco: 100.0,
         categoria: 'GASTRONOMIA_DEGUSTACOES',
+        cardSize: 'NORMAL',
       },
       {
         titulo: 'Feira de Comidas Típicas',
@@ -304,6 +315,7 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/feira-comidas.jpg',
         preco: 0.0,
         categoria: 'GASTRONOMIA_DEGUSTACOES',
+        cardSize: 'NORMAL',
       },
       {
         titulo: 'Curso de Cozinha Molecular',
@@ -315,8 +327,8 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/cozinha-molecular.jpg',
         preco: 280.0,
         categoria: 'GASTRONOMIA_DEGUSTACOES',
+        cardSize: 'NORMAL',
       },
-
       {
         titulo: 'Parque de Diversões',
         descricao: 'Diversão para toda a família com brinquedos incríveis.',
@@ -327,6 +339,7 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/parque-diversoes.jpg',
         preco: 80.0,
         categoria: 'INFANTIL_FAMILIAR',
+        cardSize: 'NORMAL',
       },
       {
         titulo: 'Teatro Infantil',
@@ -338,6 +351,7 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/teatro-infantil.jpg',
         preco: 50.0,
         categoria: 'INFANTIL_FAMILIAR',
+        cardSize: 'NORMAL',
       },
       {
         titulo: 'Festa de Natal',
@@ -349,6 +363,7 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/festa-natal.jpg',
         preco: 0.0,
         categoria: 'INFANTIL_FAMILIAR',
+        cardSize: 'NORMAL',
       },
       {
         titulo: 'Cinema ao Ar Livre',
@@ -360,6 +375,7 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/cinema-ao-ar-livre.jpg',
         preco: 0.0,
         categoria: 'INFANTIL_FAMILIAR',
+        cardSize: 'NORMAL',
       },
       {
         titulo: 'Oficina de Pintura para Crianças',
@@ -371,6 +387,31 @@ const populateDB = async (req, res) => {
         imagemUrl: 'https://exemplo.com/oficina-pintura.jpg',
         preco: 30.0,
         categoria: 'INFANTIL_FAMILIAR',
+        cardSize: 'NORMAL',
+      },
+      {
+        titulo: 'Festival de Cinema Internacional',
+        descricao: 'Uma semana de filmes premiados de todo o mundo.',
+        endereco: 'Avenida do Cinema, 1818',
+        dataInicio: new Date('2023-12-27T10:00:00Z'),
+        dataTermino: new Date('2023-12-31T22:00:00Z'),
+        ticketType: 'INGRESSO',
+        imagemUrl: 'https://exemplo.com/festival-cinema.jpg',
+        preco: 100.0,
+        categoria: 'SHOWS_ENTRETENIMENTO',
+        cardSize: 'LARGE',
+      },
+      {
+        titulo: 'Feira de Tecnologia e Inovação',
+        descricao: 'Descubra as últimas tendências em tecnologia.',
+        endereco: 'Centro de Convenções, 1919',
+        dataInicio: new Date('2023-12-28T09:00:00Z'),
+        dataTermino: new Date('2023-12-30T18:00:00Z'),
+        ticketType: 'VIP',
+        imagemUrl: 'https://exemplo.com/feira-tecnologia.jpg',
+        preco: 200.0,
+        categoria: 'WORKSHOPS_AULAS',
+        cardSize: 'LARGE',
       },
     ];
     await prisma.evento.createMany({

--- a/src/controllers/eventoController.js
+++ b/src/controllers/eventoController.js
@@ -38,6 +38,7 @@ const createEvento = async (req, res) => {
     imagemUrl,
     preco,
     categoria,
+    cardSize,
   } = req.body;
   try {
     const novoEvento = await prisma.evento.create({
@@ -51,6 +52,7 @@ const createEvento = async (req, res) => {
         imagemUrl,
         preco: Number(preco),
         categoria,
+        cardSize,
       },
     });
     return res.status(201).json(novoEvento);


### PR DESCRIPTION
## Description  
This pull request introduces a new `cardSize` field to the `Evento` model, allowing events to be displayed as either `NORMAL` or `LARGE` cards on the homepage. The `cardSize` is set during event creation and cannot be modified afterward. The key changes include:

### Backend Updates:

* **New Enum `CardSize`**:
  - Added a new enum `CardSize` with values `NORMAL` and `LARGE`.
  - The `cardSize` field is included in the `Evento` model with a default value of `NORMAL`.

* **Event Creation**:
  - Updated the `createEvento` function to include the `cardSize` field.
  - The `cardSize` is determined during event creation and cannot be updated later.

* **Database Population**:
  - Updated the `populateDB` function to include the `cardSize` field for each event.